### PR TITLE
Implement basic metadata storage

### DIFF
--- a/app/Http/Controllers/SubjectLinkController.php
+++ b/app/Http/Controllers/SubjectLinkController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Subject;
+use App\Models\SubjectLink;
+use Illuminate\Http\Request;
+
+class SubjectLinkController extends Controller
+{
+    public function store(Request $request, Subject $subject)
+    {
+        $data = $request->validate([
+            'title' => 'required|string|max:255',
+            'url' => 'required|url',
+        ]);
+
+        $subject->links()->create($data);
+
+        return redirect()->route('subject.show', $subject->id);
+    }
+
+    public function destroy(Subject $subject, SubjectLink $link)
+    {
+        if ($link->subject_id === $subject->id) {
+            $link->delete();
+        }
+
+        return redirect()->route('subject.show', $subject->id);
+    }
+}

--- a/app/Http/Controllers/SubjectMetaController.php
+++ b/app/Http/Controllers/SubjectMetaController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Subject;
+use App\Models\SubjectMeta;
+use Illuminate\Http\Request;
+
+class SubjectMetaController extends Controller
+{
+    public function store(Request $request, Subject $subject)
+    {
+        $data = $request->validate([
+            'key' => 'required|string|max:255',
+            'value' => 'nullable|string',
+        ]);
+
+        $subject->meta()->create($data);
+
+        return redirect()->route('subject.show', $subject->id);
+    }
+
+    public function destroy(Subject $subject, SubjectMeta $meta)
+    {
+        if ($meta->subject_id === $subject->id) {
+            $meta->delete();
+        }
+
+        return redirect()->route('subject.show', $subject->id);
+    }
+}

--- a/app/Models/Subject.php
+++ b/app/Models/Subject.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use App\Models\SubjectMeta;
+use App\Models\SubjectLink;
 
 class Subject extends Model
 {
@@ -16,5 +17,10 @@ class Subject extends Model
     public function meta()
     {
         return $this->hasMany(SubjectMeta::class);
+    }
+
+    public function links()
+    {
+        return $this->hasMany(SubjectLink::class);
     }
 }

--- a/app/Models/Subject.php
+++ b/app/Models/Subject.php
@@ -5,10 +5,16 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use App\Models\SubjectMeta;
 
 class Subject extends Model
 {
     use HasUlids, HasFactory;
 
     protected $fillable = ['name', 'url'];
+
+    public function meta()
+    {
+        return $this->hasMany(SubjectMeta::class);
+    }
 }

--- a/app/Models/SubjectLink.php
+++ b/app/Models/SubjectLink.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class SubjectLink extends Model
+{
+    use HasUlids, HasFactory;
+
+    protected $fillable = [
+        'subject_id',
+        'title',
+        'url',
+    ];
+
+    public function subject()
+    {
+        return $this->belongsTo(Subject::class);
+    }
+}

--- a/app/Models/SubjectMeta.php
+++ b/app/Models/SubjectMeta.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class SubjectMeta extends Model
+{
+    use HasUlids, HasFactory;
+
+    protected $table = 'subject_meta';
+
+    protected $fillable = [
+        'subject_id',
+        'key',
+        'value',
+    ];
+
+    public function subject()
+    {
+        return $this->belongsTo(Subject::class);
+    }
+}

--- a/database/factories/SubjectFactory.php
+++ b/database/factories/SubjectFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Subject;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class SubjectFactory extends Factory
+{
+    protected $model = Subject::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->word,
+        ];
+    }
+}

--- a/database/factories/SubjectLinkFactory.php
+++ b/database/factories/SubjectLinkFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\SubjectLink;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class SubjectLinkFactory extends Factory
+{
+    protected $model = SubjectLink::class;
+
+    public function definition(): array
+    {
+        return [
+            'title' => $this->faker->words(2, true),
+            'url' => $this->faker->url,
+        ];
+    }
+}

--- a/database/migrations/2025_06_07_014603_create_subject_meta_table.php
+++ b/database/migrations/2025_06_07_014603_create_subject_meta_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('subject_meta', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->ulid('subject_id');
+            $table->string('key');
+            $table->text('value')->nullable();
+            $table->timestamps();
+
+            $table->foreign('subject_id')->references('id')->on('subjects')->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('subject_meta');
+    }
+};

--- a/database/migrations/2025_06_07_020000_create_subject_links_table.php
+++ b/database/migrations/2025_06_07_020000_create_subject_links_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('subject_links', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->ulid('subject_id');
+            $table->string('title');
+            $table->string('url');
+            $table->timestamps();
+
+            $table->foreign('subject_id')->references('id')->on('subjects')->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('subject_links');
+    }
+};

--- a/docs/research.md
+++ b/docs/research.md
@@ -27,6 +27,7 @@ Minimum viable product!
 - ULIDs corresponding to objects
 - Method to create and register a new ULID
 - 1Password-ish key:value pair adding
+- Add and manage external links for each subject
 
 ## Thoughts
 

--- a/resources/views/subject/show.blade.php
+++ b/resources/views/subject/show.blade.php
@@ -21,7 +21,39 @@
         <a href="{{ route('subject.show', $subject->id) }}" class="mt-4 inline-flex items-center bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2">
             <img src="{{ 'qr/' . $subject->id . '.png' }}" alt="QR code for {{ $subject->name }}." class="mt-4 w-full h-auto rounded-lg shadow-md bg-white">
         </a>
-        
+
+        @if($subject->meta->count())
+        <div class="mt-6">
+            <h3 class="font-semibold text-gray-900 dark:text-gray-100">Metadata</h3>
+            <ul class="mt-2 space-y-1">
+                @foreach($subject->meta as $meta)
+                    <li class="flex justify-between">
+                        <span class="text-gray-700 dark:text-gray-300">{{ $meta->key }}:</span>
+                        <span class="text-gray-700 dark:text-gray-300">{{ $meta->value }}</span>
+                        <form method="POST" action="{{ route('subject.meta.destroy', [$subject->id, $meta->id]) }}">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="text-red-600">x</button>
+                        </form>
+                    </li>
+                @endforeach
+            </ul>
+        </div>
+        @endif
+
+        <form method="POST" action="{{ route('subject.meta.store', $subject->id) }}" class="mt-6 space-y-2">
+            @csrf
+            <div>
+                <input type="text" name="key" placeholder="Key" class="w-full rounded-md" required />
+            </div>
+            <div>
+                <input type="text" name="value" placeholder="Value" class="w-full rounded-md" />
+            </div>
+            <div>
+                <button type="submit" class="bg-blue-600 text-white px-3 py-1 rounded-md">Add</button>
+            </div>
+        </form>
+
     </header>
 </section>
 

--- a/resources/views/subject/show.blade.php
+++ b/resources/views/subject/show.blade.php
@@ -22,6 +22,24 @@
             <img src="{{ 'qr/' . $subject->id . '.png' }}" alt="QR code for {{ $subject->name }}." class="mt-4 w-full h-auto rounded-lg shadow-md bg-white">
         </a>
 
+        @if($subject->links->count())
+        <div class="mt-6">
+            <h3 class="font-semibold text-gray-900 dark:text-gray-100">Links</h3>
+            <ul class="mt-2 space-y-1">
+                @foreach($subject->links as $link)
+                    <li class="flex justify-between">
+                        <a href="{{ $link->url }}" class="text-blue-600 hover:underline" target="_blank">{{ $link->title }}</a>
+                        <form method="POST" action="{{ route('subject.links.destroy', [$subject->id, $link->id]) }}">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="text-red-600">x</button>
+                        </form>
+                    </li>
+                @endforeach
+            </ul>
+        </div>
+        @endif
+
         @if($subject->meta->count())
         <div class="mt-6">
             <h3 class="font-semibold text-gray-900 dark:text-gray-100">Metadata</h3>
@@ -51,6 +69,19 @@
             </div>
             <div>
                 <button type="submit" class="bg-blue-600 text-white px-3 py-1 rounded-md">Add</button>
+            </div>
+        </form>
+
+        <form method="POST" action="{{ route('subject.links.store', $subject->id) }}" class="mt-6 space-y-2">
+            @csrf
+            <div>
+                <input type="text" name="title" placeholder="Link title" class="w-full rounded-md" required />
+            </div>
+            <div>
+                <input type="url" name="url" placeholder="https://example.com" class="w-full rounded-md" required />
+            </div>
+            <div>
+                <button type="submit" class="bg-blue-600 text-white px-3 py-1 rounded-md">Add Link</button>
             </div>
         </form>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,6 +18,8 @@ Route::middleware('auth')->group(function () {
     Route::resource('subject', SubjectController::class);
     Route::post('subject/{subject}/meta', [SubjectMetaController::class, 'store'])->name('subject.meta.store');
     Route::delete('subject/{subject}/meta/{meta}', [SubjectMetaController::class, 'destroy'])->name('subject.meta.destroy');
+    Route::post('subject/{subject}/links', [SubjectLinkController::class, 'store'])->name('subject.links.store');
+    Route::delete('subject/{subject}/links/{link}', [SubjectLinkController::class, 'destroy'])->name('subject.links.destroy');
 
     // user
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,6 +16,8 @@ Route::get('/dashboard', function () {
 Route::middleware('auth')->group(function () {
 
     Route::resource('subject', SubjectController::class);
+    Route::post('subject/{subject}/meta', [SubjectMetaController::class, 'store'])->name('subject.meta.store');
+    Route::delete('subject/{subject}/meta/{meta}', [SubjectMetaController::class, 'destroy'])->name('subject.meta.destroy');
 
     // user
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');

--- a/tests/Feature/SubjectLinkTest.php
+++ b/tests/Feature/SubjectLinkTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Models\User;
+use App\Models\Subject;
+
+it('can add a link to a subject', function () {
+    $user = User::factory()->create();
+    $subject = Subject::factory()->create(['name' => 'Test Subject']);
+
+    $response = $this
+        ->actingAs($user)
+        ->post("subject/{$subject->id}/links", [
+            'title' => 'Home',
+            'url' => 'https://example.com',
+        ]);
+
+    $response->assertRedirect(route('subject.show', $subject->id, absolute: false));
+    $this->assertDatabaseHas('subject_links', [
+        'subject_id' => $subject->id,
+        'title' => 'Home',
+        'url' => 'https://example.com',
+    ]);
+});

--- a/tests/Feature/SubjectMetaTest.php
+++ b/tests/Feature/SubjectMetaTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Models\User;
+use App\Models\Subject;
+
+it('can add metadata to a subject', function () {
+    $user = User::factory()->create();
+    $subject = Subject::factory()->create(['name' => 'Test Subject']);
+
+    $response = $this
+        ->actingAs($user)
+        ->post("subject/{$subject->id}/meta", [
+            'key' => 'color',
+            'value' => 'red',
+        ]);
+
+    $response->assertRedirect(route('subject.show', $subject->id, absolute: false));
+    $this->assertDatabaseHas('subject_meta', [
+        'subject_id' => $subject->id,
+        'key' => 'color',
+        'value' => 'red',
+    ]);
+});


### PR DESCRIPTION
## Summary
- enable subject metadata storage with new database table
- add SubjectMeta model & relations
- show metadata on subject page with add/delete controls
- include tests and factory for metadata operations

## Testing
- `./vendor/bin/pest` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_6843993f545c8327aff0db2f053d73fa